### PR TITLE
Add some cmake rules for installing headers, mlir-tblgen, and mlir-opt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,3 +56,36 @@ add_subdirectory(test)
 if( LLVM_INCLUDE_EXAMPLES )
   add_subdirectory(examples)
 endif()
+
+if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+  install(DIRECTORY include/mlir include/mlir-c
+    DESTINATION include
+    COMPONENT mlir-headers
+    FILES_MATCHING
+    PATTERN "*.def"
+    PATTERN "*.h"
+    PATTERN "*.td"
+    PATTERN "*.inc"
+    PATTERN "LICENSE.TXT"
+    PATTERN ".svn" EXCLUDE
+    )
+
+  install(DIRECTORY ${MLIR_INCLUDE_DIR}/mlir ${MLIR_INCLUDE_DIR}/mlir-c
+    DESTINATION include
+    COMPONENT mlir-headers
+    FILES_MATCHING
+    PATTERN "*.def"
+    PATTERN "*.h"
+    PATTERN "*.gen"
+    PATTERN "*.inc"
+    PATTERN "CMakeFiles" EXCLUDE
+    PATTERN "config.h" EXCLUDE
+    PATTERN ".svn" EXCLUDE
+    )
+
+  if (NOT LLVM_ENABLE_IDE)
+    add_llvm_install_targets(install-mlir-headers
+                             DEPENDS mlir-headers
+                             COMPONENT mlir-headers)
+  endif()
+endif()

--- a/tools/mlir-opt/CMakeLists.txt
+++ b/tools/mlir-opt/CMakeLists.txt
@@ -55,7 +55,7 @@ if(MLIR_CUDA_CONVERSIONS_ENABLED)
     MLIRGPUtoCUDATransforms
   )
 endif()
-add_llvm_executable(mlir-opt
+add_llvm_tool(mlir-opt
  mlir-opt.cpp
 )
 llvm_update_compile_flags(mlir-opt)


### PR DESCRIPTION
A one line change is needed to LLVM to get mlir-tblgen to install as well.